### PR TITLE
fix issue 5: https://github.com/googledrive/appdatapreferences-android/i...

### DIFF
--- a/src/com/google/drive/appdatapreferences/AppdataPreferencesSyncer.java
+++ b/src/com/google/drive/appdatapreferences/AppdataPreferencesSyncer.java
@@ -103,7 +103,7 @@ public class AppdataPreferencesSyncer {
     Map<String, ?> values = mPreferences.getAll();
     String localJson = GSON.toJson(values);
     try {
-      if (localJson != null && !localJson.equals(mLastSyncedJson)) {
+      if (values.size() > 0 && localJson != null && !localJson.equals(mLastSyncedJson)) {
         updateRemote(localJson);
       } else {
         updateLocal();


### PR DESCRIPTION
...ssues/5 by verifying that values is greater 0.

This fixing the first sync not being completed if the local prefs are empty. 

However, I can see how this could not be sufficient under certain conditions. 
